### PR TITLE
Fix inaccurate `nym-client` subcommand term

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ The last lines of the output will be the `exit-node`'s address. You'll need this
 You can go ahead and start the Nym client after you create the config:
 
 ```text
-nym-client start --id exit-node
+nym-client run --id exit-node
 ```
 
 You need to start Spook's exit module, do this by cloning the repo and building the project:


### PR DESCRIPTION
Latest versions of `nym-client` do not have a `start` subcommand:

```
~/Desktop
❯ nym-client start --id exit-node


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (nym-client - version 1.1.8)


error: unrecognized subcommand 'start'

Usage: nym-client [OPTIONS] <COMMAND>

For more information, try '--help'.

~/Desktop
❯ nym-client run --id exit-node                                                                                                              ✘ 2


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (nym-client - version 1.1.8)
```